### PR TITLE
Properly check SNOMED/LOINC translations

### DIFF
--- a/schematron/Consolidation.sch
+++ b/schematron/Consolidation.sch
@@ -1148,7 +1148,7 @@ Schematron generated from Trifolia on 7/20/2021
       <sch:assert id="a-81-14831" test="not(cda:participant/cda:time) or cda:participant/cda:time[count(cda:low)=1]">The time, if present, SHALL contain exactly one [1..1] low (CONF:81-14831).</sch:assert>
       <sch:assert id="a-81-19090" test="cda:statusCode[@code='completed']">This statusCode SHALL contain exactly one [1..1] @code="completed" Completed (CodeSystem: HL7ActStatus urn:oid:2.16.840.1.113883.5.14 STATIC) (CONF:81-19090).</sch:assert>
       <sch:assert id="a-81-26451" test="cda:participant[@typeCode='IND']">Such participants SHALL contain exactly one [1..1] @typeCode="IND" (CONF:81-26451).</sch:assert>
-      <sch:assert id="a-81-14600-c" test="cda:value/@codeSystem='2.16.840.1.113883.6.1' or cda:value/@codeSystem='2.16.840.1.113883.6.96'">The code **SHALL** be selected from LOINC (codeSystem: 2.16.840.1.113883.6.1) or SNOMED CT (CodeSystem: 2.16.840.1.113883.6.96) (CONF:81-14600).</sch:assert>
+      <sch:assert id="a-81-14600-c" test="cda:value/@codeSystem='2.16.840.1.113883.6.1' or cda:value/@codeSystem='2.16.840.1.113883.6.96' or cda:value[@nullFlavor and not(@codeSystem)]">The code **SHALL** be selected from LOINC (codeSystem: 2.16.840.1.113883.6.1) or SNOMED CT (CodeSystem: 2.16.840.1.113883.6.96) (CONF:81-14600).</sch:assert>
     </sch:rule>
     <sch:rule id="r-urn-oid-2.16.840.1.113883.10.20.22.4.72-errors" context="cda:observation[cda:templateId[@root='2.16.840.1.113883.10.20.22.4.72']]">
       <sch:extends rule="r-urn-oid-2.16.840.1.113883.10.20.22.4.72-errors-abstract" />

--- a/schematron/Consolidation.sch
+++ b/schematron/Consolidation.sch
@@ -1148,7 +1148,7 @@ Schematron generated from Trifolia on 7/20/2021
       <sch:assert id="a-81-14831" test="not(cda:participant/cda:time) or cda:participant/cda:time[count(cda:low)=1]">The time, if present, SHALL contain exactly one [1..1] low (CONF:81-14831).</sch:assert>
       <sch:assert id="a-81-19090" test="cda:statusCode[@code='completed']">This statusCode SHALL contain exactly one [1..1] @code="completed" Completed (CodeSystem: HL7ActStatus urn:oid:2.16.840.1.113883.5.14 STATIC) (CONF:81-19090).</sch:assert>
       <sch:assert id="a-81-26451" test="cda:participant[@typeCode='IND']">Such participants SHALL contain exactly one [1..1] @typeCode="IND" (CONF:81-26451).</sch:assert>
-      <sch:assert id="a-81-14600-c" test="not(tested_here_yet)">The code **SHALL** be selected from LOINC (codeSystem: 2.16.840.1.113883.6.1) or SNOMED CT (CodeSystem: 2.16.840.1.113883.6.96) (CONF:81-14600).</sch:assert>
+      <sch:assert id="a-81-14600-c" test="cda:value/@codeSystem='2.16.840.1.113883.6.1' or cda:value/@codeSystem='2.16.840.1.113883.6.96'">The code **SHALL** be selected from LOINC (codeSystem: 2.16.840.1.113883.6.1) or SNOMED CT (CodeSystem: 2.16.840.1.113883.6.96) (CONF:81-14600).</sch:assert>
     </sch:rule>
     <sch:rule id="r-urn-oid-2.16.840.1.113883.10.20.22.4.72-errors" context="cda:observation[cda:templateId[@root='2.16.840.1.113883.10.20.22.4.72']]">
       <sch:extends rule="r-urn-oid-2.16.840.1.113883.10.20.22.4.72-errors-abstract" />
@@ -2838,7 +2838,7 @@ Schematron generated from Trifolia on 7/20/2021
       <sch:assert id="a-1198-19117" test="cda:statusCode[@code='completed']">This statusCode SHALL contain exactly one [1..1] @code="completed" Completed (CodeSystem: HL7ActStatus urn:oid:2.16.840.1.113883.5.14 STATIC) (CONF:1198-19117).</sch:assert>
       <sch:assert id="a-1198-8555-c" test="not(tested)">If Observation/value is a physical quantity (xsi:type="PQ"), the unit of measure **SHALL** be selected from ValueSet UnitsOfMeasureCaseSensitive (2.16.840.1.113883.1.11.12839) *DYNAMIC* (CONF:1198-8555).</sch:assert>
       <sch:assert id="a-1198-31868" test="count(cda:effectiveTime)=1">SHALL contain exactly one [1..1] effectiveTime (CONF:1198-31868).</sch:assert>
-      <sch:assert id="a-1198-32951-c" test="not(tested)">If @codeSystem is not LOINC, then this code **SHALL** contain at least one [1..*] translation, which **SHOULD** be selected from CodeSystem LOINC (urn:oid:2.16.840.1.113883.6.1) (CONF:1198-32951).</sch:assert>
+      <sch:assert id="a-1198-32951-c" test="cda:code/@codeSystem='2.16.840.1.113883.6.1' or cda:code/cda:translation">If @codeSystem is not LOINC, then this code **SHALL** contain at least one [1..*] translation, which **SHOULD** be selected from CodeSystem LOINC (urn:oid:2.16.840.1.113883.6.1) (CONF:1198-32951).</sch:assert>
     </sch:rule>
     <sch:rule id="r-urn-hl7ii-2.16.840.1.113883.10.20.22.4.38-2015-08-01-errors" context="cda:observation[cda:templateId[@root='2.16.840.1.113883.10.20.22.4.38' and @extension='2015-08-01']]">
       <sch:extends rule="r-urn-hl7ii-2.16.840.1.113883.10.20.22.4.38-2015-08-01-errors-abstract" />


### PR DESCRIPTION
Fixes: https://jira.hl7.org/browse/CDA-2032  (#3 & #5)

###  [Social History Observation](http://www.hl7.org/ccdasearch/templates/2.16.840.1.113883.10.20.22.4.38.html) - (CONF:1198-32951)
The sample file contains a valid code+translation:
```
<observation classCode="OBS" moodCode="EVN">
	<!-- ** Social history observation (V3) ** -->
	<templateId root="2.16.840.1.113883.10.20.22.4.38" extension="2015-08-01"/>
	<templateId root="2.16.840.1.113883.10.20.22.4.38"/>
	<id root="37f76c51-6411-4e1d-8a37-957fd49d2cef"/>
	<code code="160573003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Alcohol intake">
		<translation code="74013-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Alcoholic drinks per day"/>
	</code>
```
Now
- If you remove the translation, the schematron will fail
- If you remove the translation but set the code/@codeSystem to LOINC (i.e. just bring the LOINC codes up to the top level), the schematron will pass
- If you remove the translation and set the @codeSystem to anything else (or set a nullFlavor), the schematron will pass

### [Caregiver Characteristics](https://www.hl7.org/ccdasearch/templates/2.16.840.1.113883.10.20.22.4.72.html)
The linked guide example passes validation, but now if you change the value/@codeSystem to be anything other than LOINC or SNOMED, it will throw an error